### PR TITLE
Modernize FontDescriptor's Hashable

### DIFF
--- a/HyperCardCommon/HyperCardCommon/CommonTypes.swift
+++ b/HyperCardCommon/HyperCardCommon/CommonTypes.swift
@@ -133,33 +133,166 @@ public enum UserLevel: Int {
 }
 
 /// All the variants that can be applied to a font
-public struct TextStyle: Equatable, CustomStringConvertible {
+public struct TextStyle: Equatable, CustomStringConvertible, OptionSet, Hashable {
+    public var rawValue: UInt8
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
     
     /// Characters are drawn thicker
-    public var bold: Bool
+    public static var bold: TextStyle {
+        return TextStyle(rawValue: 1 << 0)
+    }
     
     /// Characters are drawn slanted
-    public var italic: Bool
-    
+    public static var italic: TextStyle {
+        return TextStyle(rawValue: 1 << 1)
+    }
+
     /// Characters are drawn with an under-line
-    public var underline: Bool
-    
+    public static var underline: TextStyle {
+        return TextStyle(rawValue: 1 << 2)
+    }
+
     /// The borders of the characters are drawn in black and the interiors in white
-    public var outline: Bool
+    public static var outline: TextStyle {
+        return TextStyle(rawValue: 1 << 3)
+    }
+
+    /// Characters are drawn with an under-line
+    public static var shadow: TextStyle {
+        return TextStyle(rawValue: 1 << 4)
+    }
     
-    /// Characters are drawn outlined and with a shadow
-    public var shadow: Bool
-    
-    /// Characters are drawn closer from each other
-    public var condense: Bool
-    
+    /// Characters are drawn closer to each other
+    public static var condense: TextStyle {
+        return TextStyle(rawValue: 1 << 5)
+    }
+
     /// Characters are drawn further from each other
-    public var extend: Bool
-    
+    public static var extend: TextStyle {
+        return TextStyle(rawValue: 1 << 6)
+    }
+
     /// Specific HyperCard type used to mark the hyperlinks
-    public var group: Bool
-    
+    public static var group: TextStyle {
+        return TextStyle(rawValue: 1 << 7)
+    }
+	
+    /// Characters are drawn thicker
+    public var bold: Bool {
+        get {
+            return self.contains(TextStyle.bold)
+        }
+        set {
+            if newValue {
+                self.insert(TextStyle.bold)
+            } else {
+                self.remove(TextStyle.bold)
+            }
+        }
+    }
+	
+    /// Characters are drawn slanted
+    public var italic: Bool {
+        get {
+            return self.contains(TextStyle.italic)
+        }
+        set {
+            if newValue {
+                self.insert(TextStyle.italic)
+            } else {
+                self.remove(TextStyle.italic)
+            }
+        }
+    }
+	
+    /// Characters are drawn with an under-line
+    public var underline: Bool {
+        get {
+            return self.contains(TextStyle.underline)
+        }
+        set {
+            if newValue {
+                self.insert(TextStyle.underline)
+            } else {
+                self.remove(TextStyle.underline)
+            }
+        }
+    }
+	
+    /// The borders of the characters are drawn in black and the interiors in white
+    public var outline: Bool {
+        get {
+            return self.contains(TextStyle.outline)
+        }
+        set {
+            if newValue {
+                self.insert(TextStyle.outline)
+            } else {
+                self.remove(TextStyle.outline)
+            }
+        }
+    }
+	
+    /// Characters are drawn outlined and with a shadow
+    public var shadow: Bool {
+        get {
+            return self.contains(TextStyle.shadow)
+        }
+        set {
+            if newValue {
+                self.insert(TextStyle.shadow)
+            } else {
+                self.remove(TextStyle.shadow)
+            }
+        }
+    }
+	
+    /// Characters are drawn closer to each other
+    public var condense: Bool {
+        get {
+            return self.contains(TextStyle.condense)
+        }
+        set {
+            if newValue {
+                self.insert(TextStyle.condense)
+            } else {
+                self.remove(TextStyle.condense)
+            }
+        }
+    }
+	
+    /// Characters are drawn further from each other
+    public var extend: Bool {
+        get {
+            return self.contains(TextStyle.extend)
+        }
+        set {
+            if newValue {
+                self.insert(TextStyle.extend)
+            } else {
+                self.remove(TextStyle.extend)
+            }
+        }
+    }
+	
+    /// Specific HyperCard type used to mark the hyperlinks
+    public var group: Bool {
+        get {
+            return self.contains(TextStyle.group)
+        }
+        set {
+            if newValue {
+                self.insert(TextStyle.group)
+            } else {
+                self.remove(TextStyle.group)
+            }
+        }
+    }
+	
     public init(bold: Bool = false, italic: Bool = false, underline: Bool = false, outline: Bool = false, shadow: Bool = false, condense: Bool = false, extend: Bool = false, group: Bool = false) {
+        rawValue = 0
         self.bold = bold
         self.italic = italic
         self.underline = underline
@@ -221,6 +354,7 @@ public extension TextStyle {
     
     /// Init a text style from a 8 bit flag
     public init(flags: Int) {
+		rawValue = 0
         bold = (flags & (1 << 0)) != 0
         italic = (flags & (1 << 1)) != 0
         underline = (flags & (1 << 2)) != 0

--- a/HyperCardCommon/HyperCardCommon/FontManager.swift
+++ b/HyperCardCommon/HyperCardCommon/FontManager.swift
@@ -159,17 +159,10 @@ private struct FontDescriptor: Equatable, Hashable {
         self.style = style
     }
     
-    public var hashValue: Int {
-        var hash = identifier &* 31 ^ size
-        hash = style.bold ? hash << 3 ^ 80 : hash
-        hash = style.italic ? hash << 3 ^ 70 : hash
-        hash = style.underline ? hash << 3 ^ 60 : hash
-        hash = style.shadow ? hash << 3 ^ 50 : hash
-        hash = style.outline ? hash << 3 ^ 40 : hash
-        hash = style.condense ? hash << 3 ^ 30 : hash
-        hash = style.extend ? hash << 3 ^ 20 : hash
-        hash = style.group ? hash << 3 ^ 10 : hash
-        return hash
+    public func hash(into hasher: inout Hasher) {
+        identifier.hash(into: &hasher)
+        size.hash(into: &hasher)
+        style.hash(into: &hasher)
     }
     
     public static func ==(f1: FontDescriptor, f2: FontDescriptor) -> Bool {


### PR DESCRIPTION
Make `FontDescriptor` use the new `hash(into:)` method.
Also made `TextStyle` an `OptionSet`.

Closes #8.