### PR TITLE
Added resource name to file name of export

### DIFF
--- a/HyperCardPreview/ResourceController.swift
+++ b/HyperCardPreview/ResourceController.swift
@@ -519,7 +519,7 @@ class ResourceController: NSWindowController, NSCollectionViewDataSource, NSColl
                     
                     let fileExtension = self.getFileExtensionForResource(resource)
                     let fileSuffix = (fileExtension != nil) ? ".\(fileExtension!)" : ""
-                    let resourceFileName = "res-\(resource.type)-\(resource.identifier)\(fileSuffix)"
+                    let resourceFileName = "res-\(resource.type)-\(resource.identifier)-\(resource.name)\(fileSuffix)"
                     let resourceUrl = URL(fileURLWithPath: resourceFileName, relativeTo: url)
                     
                     


### PR DESCRIPTION
When exporting multiple resources at once it put the resource ID in the file name, but did not export the resource name. I wanted to preserve both, so I added the resource name after the ID.